### PR TITLE
Fix timeout issue not being triggered

### DIFF
--- a/hue-motion/hue-motion.ino
+++ b/hue-motion/hue-motion.ino
@@ -33,20 +33,23 @@ void setup(void) {
 void loop() {
   bool movementDetected = digitalRead(PIR_PIN) == HIGH;
   bool okToSend = last != movementDetected;
-  last = movementDetected;
 
   if (movementDetected) {
     lastMovement = millis();
     Serial.println("Movement detected");
-    if (okToSend) {
+    
+    if (lastSent != "on") {
       Serial.println("Sending ON");
       sendHttpRequest(true);
     }
   } else {
     Serial.println("No movement detected");
-    if (millis() - lastMovement > idlePeriod && okToSend) {
-      Serial.println("Passed idlePeriod - sending OFF");
-      sendHttpRequest(false);
+    if (millis() - lastMovement > idlePeriod) {
+
+      if (lastSent != "off") {
+        Serial.println("Passed idlePeriod - sending OFF");
+        sendHttpRequest(false);
+      }
     }
   }
   
@@ -61,8 +64,10 @@ void sendHttpRequest(bool turnOn) {
     http.addHeader("Content-Type", "text/plain;charset=UTF-8");
     if (turnOn) {
       http.PUT("{\"on\":true}");
+      lastSent = "on";
     } else {
       http.PUT("{\"on\":false}");
+      lastSent = "off";
     }
     http.end();
   } else {


### PR DESCRIPTION
The timeout isn't being triggered because the last is being set before the timeout time. So to fix I rearranged the logic to make it so that when the state of the light is changed, it changes a variable called `lastSent` this way, when the timeout checks to see if it can be sent, it looks to see if the state of the light is already set to the same or different light state (and same for when turning on the light).